### PR TITLE
Add Flask timetable web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Branches allow you to separate your work from the `main` branch. In other words,
 
 6. Wait about 20 seconds then refresh this page (the one you're following instructions from). [GitHub Actions](https://docs.github.com/en/actions) will automatically update to the next step.
 
+## Timetable web app
+
+This repository includes a small Flask application for adding timetable entries.
+
+### Running locally
+1. Install dependencies with `pip install Flask`.
+2. Run the app using `python app.py` and open `http://localhost:5000` in your browser.
+
+
 <footer>
 
 <!--

--- a/app.py
+++ b/app.py
@@ -1,0 +1,20 @@
+from flask import Flask, render_template, request, redirect, url_for
+
+app = Flask(__name__)
+
+# In-memory list to store timetable entries
+# Each entry is a dictionary with 'subject' and 'time'
+timetable = []
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        subject = request.form.get('subject')
+        time = request.form.get('time')
+        if subject and time:
+            timetable.append({'subject': subject, 'time': time})
+        return redirect(url_for('index'))
+    return render_template('index.html', timetable=timetable)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Timetable</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 600px; margin: auto; }
+        form div { margin-bottom: 0.5em; }
+        label { display: inline-block; width: 80px; }
+        ul { list-style-type: none; padding: 0; }
+        li { padding: 0.25em 0; border-bottom: 1px solid #ddd; }
+    </style>
+</head>
+<body>
+    <h1>Timetable</h1>
+    <form method="post">
+        <div>
+            <label for="subject">Subject:</label>
+            <input type="text" id="subject" name="subject" required>
+        </div>
+        <div>
+            <label for="time">Time:</label>
+            <input type="text" id="time" name="time" required>
+        </div>
+        <button type="submit">Add</button>
+    </form>
+
+    <h2>Entries</h2>
+    <ul>
+        {% for entry in timetable %}
+            <li>{{ entry.time }} - {{ entry.subject }}</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple Flask app (`app.py`) and template (`templates/index.html`)
- update README with instructions for running the new timetable web app

## Testing
- `python3 app.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68768d1fbee48322a0f82120b6208a62